### PR TITLE
Fix day of week function

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "__MSG_appName__",
-    "version": "0.0.3",
+    "version": "0.0.5",
     "manifest_version": 2,
     "description": "__MSG_appDescription__",
     "icons": {

--- a/app/scripts/openair.js
+++ b/app/scripts/openair.js
@@ -348,13 +348,13 @@ app.service('OpenAirService', function() {
      */
     this.getDayNum = function(dayCode) {
         var  weekdays = [];
-        weekdays.mo = 0;
-        weekdays.tu = 1;
-        weekdays.we = 2;
-        weekdays.th = 3;
-        weekdays.fr = 4;
-        weekdays.sa = 5;
-        weekdays.su = 6;
+	    weekdays.su = 0;
+        weekdays.mo = 1;
+        weekdays.tu = 2;
+        weekdays.we = 3;
+        weekdays.th = 4;
+        weekdays.fr = 5;
+        weekdays.sa = 6;
         return weekdays[dayCode];
     };
 });


### PR DESCRIPTION
Re-ordered days of week in getDayNum() function in openair.js.

I found that due to my week starting on Sunday rather than Monday in OpenAir, that saving timesheets resulted in all of the time entered being moved back one day.
