### PR TITLE
Modified the "days of the week" code to make the first day configurable

### DIFF
--- a/app/options.html
+++ b/app/options.html
@@ -51,6 +51,19 @@
                     </select>
                     <p class="description">Choosing "Yes" will automatically save your timesheet after 15 minutes of inactivity.</p>
                 </div>
+                <div class="form-input-wrapper">
+                    <label for="firstDayOfWeek">First day of the week</label>
+                    <select id="firstDayOfWeek"  name="firstDayOfWeek" ng-model="firstDayOfWeek">
+                        <option value="su">Sunday</option>
+                        <option value="mo">Monday</option>
+                        <option value="tu">Tuesday</option>
+                        <option value="we">Wednesday</option>
+                        <option value="th">Thursday</option>
+                        <option value="fr">Friday</option>
+                        <option value="sa">Saturday</option>
+                    </select>
+                    <p class="description">Select the first day of the week. This can be set by the business, and will be the first time entry column.</p>
+                </div>
                 <!--
                 <div class="form-input-wrapper">
                     <label for="persistentTimers">Persistent timers</label>

--- a/app/scripts/openair.js
+++ b/app/scripts/openair.js
@@ -13,6 +13,8 @@
  */
 app.service('OpenAirService', function() {
 
+    this.firstDayOfWeek = 'mo';
+
     var parent = this; // Used in functions below to reference other functions below.
 
     /**
@@ -382,6 +384,7 @@ app.service('OpenAirService', function() {
 
     /**
      * Helper function to convert two digit day code to integer.
+     * This takes the "first day of week" setting into account
      *
      * @TODO: Start using numbers instead of day codes. It'll remove a lot of dumb logic.
      *
@@ -389,14 +392,29 @@ app.service('OpenAirService', function() {
      * @returns {int}
      */
     this.getDayNum = function(dayCode) {
-        var  weekdays = [];
-        weekdays.mo = 0;
-        weekdays.tu = 1;
-        weekdays.we = 2;
-        weekdays.th = 3;
-        weekdays.fr = 4;
-        weekdays.sa = 5;
-        weekdays.su = 6;
+        var  weekdays = {};
+        var days = [
+            'su',
+            'mo',
+            'tu',
+            'we',
+            'th',
+            'fr',
+            'sa',
+        ];
+
+        // figure out which day is the first day
+        var firstDayStr = parent.firstDayOfWeek;
+        var firstDayIndex = days.findIndex(function (d) { return d === firstDayStr; });
+
+        // assign integers for each day, looping around where necessary
+        days.forEach(function (day, i) {
+            var index = i - firstDayIndex;
+            if(index < 0) {
+                index = days.length + index;
+            }
+            weekdays[day] = index;
+        });
         return weekdays[dayCode];
     };
 

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -15,7 +15,8 @@ app.controller('OptionsController', ['$scope', function($scope) {
             timeFormat : $scope.timeFormat,
             multipleTimers : $scope.multipleTimers,
             persistentTimers : $scope.persistentTimers,
-            autosave : $scope.autosave
+            autosave : $scope.autosave,
+            firstDayOfWeek : $scope.firstDayOfWeek,
         }, function() {
             $scope.status = "Settings saved successfully.";
             $scope.$apply();
@@ -69,6 +70,7 @@ app.controller('OptionsController', ['$scope', function($scope) {
         $scope.load('multipleTimers', 1);
         $scope.load('persistentTimers', 1);
         $scope.load('autosave', 0);
+        $scope.load('firstDayOfWeek', 'mo');
     };
 
     // And away we go...


### PR DESCRIPTION
In OpenAir, the business is able to change the first day of the week. Previously this extension had the first day hardcoded to "Monday". In this change I add a new dropdown to the Options menu allowing the user to select the first day. It still defaults to Monday.

Since loading the options is asynchronous, we can no longer rely on "getDayNum()" to return the correct day until we have loaded this setting. That means we need to delay the timesheet code that depends on this function. I've modifieded that code to a callback after the "firstDayOfWeek" setting is loaded.

I don't know Angular, especially not Angular 1. So please correct any bad Angular practices. There may be an easier way to update the $weekdays and $reverseWeekdays after we've loaded the option.

I had to update a few NPM packages to be able to run this project. I can create a separate PR with those updates.

See issue #30 
