### PR TITLE
Added *.app.openair.com to active domains. This allows for using the …

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "__MSG_appName__",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "manifest_version": 2,
     "description": "__MSG_appDescription__",
     "icons": {
@@ -29,7 +29,8 @@
         {
             "matches": [
                 "https://www.openair.com/timesheet.pl*",
-                "https://preview.openair.com/timesheet.pl*"
+                "https://preview.openair.com/timesheet.pl*",
+                "https://*.app.openair.com/timesheet.pl*"
             ],
             "css": [
                 "styles/main.css",


### PR DESCRIPTION
…extension with the new domain format for Openair with SSO.

Bumped version number as well.